### PR TITLE
Fixat teste de integrare

### DIFF
--- a/HealthcareManagement.IntegrationTests/AppointmentsControllerIntegrationTests.cs
+++ b/HealthcareManagement.IntegrationTests/AppointmentsControllerIntegrationTests.cs
@@ -10,6 +10,9 @@ using Newtonsoft.Json;
 using FluentAssertions;
 using Domain.Entities;
 using Application.Use_Cases.Commands.AppointmentCommands;
+using DotNetEnv;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace HealthcareManagement.IntegrationTests
 {
@@ -24,6 +27,8 @@ namespace HealthcareManagement.IntegrationTests
         {
             this.factory = factory.WithWebHostBuilder(builder =>
             {
+                Env.Load();
+                var clientUrl = Environment.GetEnvironmentVariable("CLIENT_URL");
                 builder.ConfigureServices(services =>
                 {
                     var descriptors = services.Where(
@@ -37,6 +42,15 @@ namespace HealthcareManagement.IntegrationTests
                     services.AddDbContext<ApplicationDbContext>(options =>
                     {
                         options.UseInMemoryDatabase("InMemoryDbForTesting");
+                    });
+                });
+                
+                //Injectam acel URL in care se afla CLIENT_URL
+                builder.ConfigureAppConfiguration((context, configBuilder) =>
+                {
+                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        { "CLIENT_URL", clientUrl } 
                     });
                 });
             });

--- a/HealthcareManagement.IntegrationTests/AppointmentsControllerIntegrationTests.cs
+++ b/HealthcareManagement.IntegrationTests/AppointmentsControllerIntegrationTests.cs
@@ -45,14 +45,6 @@ namespace HealthcareManagement.IntegrationTests
                     });
                 });
                 
-                //Injectam acel URL in care se afla CLIENT_URL
-                builder.ConfigureAppConfiguration((context, configBuilder) =>
-                {
-                    configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
-                    {
-                        { "CLIENT_URL", clientUrl } 
-                    });
-                });
             });
 
             var scope = this.factory.Services.CreateScope();

--- a/HealthcareManagement.IntegrationTests/HealthcareManagement.IntegrationTests.csproj
+++ b/HealthcareManagement.IntegrationTests/HealthcareManagement.IntegrationTests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />

--- a/HealthcareManagement/Program.cs
+++ b/HealthcareManagement/Program.cs
@@ -17,6 +17,7 @@ builder.Configuration["ConnectionStrings:Port"] = Environment.GetEnvironmentVari
 builder.Configuration["ConnectionStrings:Username"] = Environment.GetEnvironmentVariable("DB_USER");
 builder.Configuration["ConnectionStrings:Password"] = Environment.GetEnvironmentVariable("DB_PASSWORD");
 builder.Configuration["ConnectionStrings:Database"] = Environment.GetEnvironmentVariable("DB_NAME");
+builder.Configuration["CORS:ClientUrl"] = Environment.GetEnvironmentVariable("CLIENT_URL");
 
 var MyAllowSpecificOrigin = "MyAllowSpecificOrigin";
 builder.Services.AddCors(options =>
@@ -24,7 +25,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy(name: MyAllowSpecificOrigin,
                     policy =>
                     {
-                        policy.WithOrigins(Environment.GetEnvironmentVariable("CLIENT_URL")!);
+                        policy.WithOrigins(Environment.GetEnvironmentVariable("CLIENT_URL") ?? "http://localhost:4200");
                         policy.AllowAnyHeader();
                         policy.AllowAnyMethod();
                     });
@@ -64,7 +65,7 @@ app.UseCors(MyAllowSpecificOrigin);
 
 app.UseHttpsRedirection();
 
-app.MapControllers();
+app.MapControllers();   
 app.Run();
 
 public partial class Program

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
Am rezolvat eroarea de la testele de integrare. Problema era ca nu putea accesa variabila CLIENT_URL din .env-ul din API. Pentru a functiona, vom avea un .env separat si in proiectul de test, care are continutul:
CLIENT_URL=http://localhost:4200 (la fel cu celalalt env)

Asta ca sa nu fie hardcodat nicaieri url-ul respectiv, altfel ar fi de ajuns modificarea din program.cs: policy.WithOrigins(Environment.GetEnvironmentVariable("CLIENT_URL") ?? "http://localhost:4200");

Sa mi spuneti cu care varianta sunteti de acord ca sa stiu ce modific (eu personal cred ca prima e mai ok).